### PR TITLE
Add trading bot task outline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # PrintMoney
-training ai bot to trade forme
+
+This repository aims to experiment with building an automated trading bot for options. Below is a suggested task list for training a model. This is **not** financial advice and profitability is not guaranteed. Proceed at your own risk and consult a professional financial advisor if needed.
+
+## Tasks
+
+1. **Collect data**: Gather historical option prices, underlying asset data, and relevant market indicators from reliable data vendors.
+2. **Clean and preprocess**: Handle missing values, adjust for corporate actions (splits, dividends), and align timestamps across data sources.
+3. **Feature engineering**: Create features such as implied volatility, Greeks (delta, gamma, theta, vega), moving averages, and other technical indicators.
+4. **Model selection**: Test a variety of algorithms (e.g., tree-based models, neural networks, reinforcement learning) to forecast option price movements or risk metrics.
+5. **Backtesting**: Evaluate the model on historical data with realistic transaction costs and slippage to assess performance and drawdowns.
+6. **Risk management**: Define position sizing rules and risk limits (e.g., maximum exposure per trade, stop-loss thresholds).
+7. **Paper trading**: Run the strategy in a simulated environment to verify results before committing real capital.
+8. **Deployment**: Automate order execution through a broker API while monitoring latency and system reliability.
+9. **Monitoring and iteration**: Continuously track live performance, retrain the model with new data, and refine features or parameters as needed.
+
+## Disclaimer
+
+This project is for educational purposes only. Trading options involves significant risk, and no outcome is guaranteed. You are solely responsible for any trades executed using code or models derived from this repository.


### PR DESCRIPTION
## Summary
- expand README with tasks for building an options trading bot
- note risk and emphasize educational intent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850e9e565c88326b1be1b0bf05e2084