### PR TITLE
Add dashboard for visualizing trading metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,27 @@ This repository aims to experiment with building an automated trading bot for op
 ## Tasks
 
 1. **Collect data**: Gather historical option prices, underlying asset data, and relevant market indicators from reliable data vendors. The `collect_data.py` script supports a `--sample-dir` option for loading CSV files when network access is unavailable.
-2. **Clean and preprocess**: Handle missing values, adjust for corporate actions (splits, dividends), and align timestamps across data sources.
-3. **Feature engineering**: Create features such as implied volatility, Greeks (delta, gamma, theta, vega), moving averages, and other technical indicators.
-4. **Model selection**: Test a variety of algorithms (e.g., tree-based models, neural networks, reinforcement learning) to forecast option price movements or risk metrics.
+2. **Clean and preprocess**: Handle missing values, adjust for corporate actions (splits, dividends), and align timestamps across data sources. The `preprocess_data.py` script generates cleaned CSV files with basic features like moving averages.
+3. **Feature engineering**: Create additional features such as implied volatility, Greeks (delta, gamma, theta, vega), moving averages, and other technical indicators. The `feature_engineering.py` script illustrates a simple approach for adding RSI, volatility, and option time to expiration.
+4. **Model selection**: Test a variety of algorithms (e.g., tree-based models, neural networks, reinforcement learning) to forecast option price movements or risk metrics. The `model_selection.py` script provides a simple logistic regression and random forest baseline.
 5. **Backtesting**: Evaluate the model on historical data with realistic transaction costs and slippage to assess performance and drawdowns.
 6. **Risk management**: Define position sizing rules and risk limits (e.g., maximum exposure per trade, stop-loss thresholds).
 7. **Paper trading**: Run the strategy in a simulated environment to verify results before committing real capital.
 8. **Deployment**: Automate order execution through a broker API while monitoring latency and system reliability.
 9. **Monitoring and iteration**: Continuously track live performance, retrain the model with new data, and refine features or parameters as needed.
+
+## Visual Dashboard
+
+After running the preprocessing, feature engineering, and model selection steps,
+launch `dashboard.py` with Streamlit to view key metrics:
+
+```bash
+streamlit run dashboard.py
+```
+
+The dashboard displays price charts with moving averages, RSI and volatility
+curves, the latest model accuracy scores, and a snapshot of recent option
+features.
 
 ## Disclaimer
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,46 @@
+import streamlit as st
+import pandas as pd
+from pathlib import Path
+
+
+def load_data(feature_dir: str = "features", model_dir: str = "models"):
+    """Load engineered features and model scores."""
+    underlying_path = Path(feature_dir) / "underlying_features.csv"
+    options_path = Path(feature_dir) / "options_features.csv"
+    underlying_df = pd.read_csv(underlying_path, parse_dates=["Date"])
+    options_df = pd.read_csv(options_path)
+
+    scores_file = Path(model_dir) / "scores.txt"
+    scores = {}
+    if scores_file.exists():
+        for line in scores_file.read_text().splitlines():
+            if "=" in line:
+                key, val = line.split("=", 1)
+                scores[key] = float(val) if val != "nan" else float("nan")
+    return underlying_df, options_df, scores
+
+
+def main() -> None:
+    st.title("Trading Bot Dashboard")
+
+    underlying_df, options_df, scores = load_data()
+
+    st.subheader("Underlying Price with Moving Averages")
+    st.line_chart(
+        underlying_df.set_index("Date")[["Close", "close_ma5", "close_ma20"]]
+    )
+
+    st.subheader("RSI and Volatility")
+    st.line_chart(underlying_df.set_index("Date")[["rsi14", "vol30d"]])
+
+    if scores:
+        st.subheader("Model Accuracy")
+        score_df = pd.DataFrame(list(scores.items()), columns=["Model", "Accuracy"])
+        st.table(score_df)
+
+    st.subheader("Latest Option Features")
+    st.dataframe(options_df.tail())
+
+
+if __name__ == "__main__":
+    main()

--- a/feature_engineering.py
+++ b/feature_engineering.py
@@ -1,0 +1,64 @@
+import argparse
+from pathlib import Path
+import pandas as pd
+
+
+def add_rsi(df: pd.DataFrame, window: int = 14) -> pd.DataFrame:
+    """Compute the Relative Strength Index (RSI)."""
+    delta = df['Close'].diff()
+    gain = delta.clip(lower=0)
+    loss = -delta.clip(upper=0)
+    avg_gain = gain.rolling(window=window).mean()
+    avg_loss = loss.rolling(window=window).mean()
+    rs = avg_gain / avg_loss
+    df[f'rsi{window}'] = 100 - 100 / (1 + rs)
+    return df
+
+
+def add_volatility(df: pd.DataFrame, window: int = 30) -> pd.DataFrame:
+    """Annualized rolling volatility based on returns."""
+    df[f'vol{window}d'] = df['returns'].rolling(window=window).std() * (252 ** 0.5)
+    return df
+
+
+def engineer_underlying_features(path: Path) -> pd.DataFrame:
+    """Load cleaned underlying data and compute indicators."""
+    df = pd.read_csv(path, parse_dates=['Date'])
+    if 'returns' not in df.columns:
+        df['returns'] = df['Close'].pct_change()
+    df = add_rsi(df)
+    df = add_volatility(df)
+    return df
+
+
+def engineer_option_features(path: Path, reference_date: pd.Timestamp) -> pd.DataFrame:
+    """Add basic option-related features."""
+    df = pd.read_csv(path)
+    df['mid_price'] = (df['Bid'] + df['Ask']) / 2
+    df['time_to_expiration'] = (pd.to_datetime(df['expiration']) - reference_date).dt.days
+    return df
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate engineered features for trading models")
+    parser.add_argument("underlying", help="CSV file output from preprocess_data.py for the underlying")
+    parser.add_argument("options", help="CSV file output from preprocess_data.py for options")
+    parser.add_argument("--output", default="features", help="Directory to store feature CSV files")
+    args = parser.parse_args()
+
+    underlying_path = Path(args.underlying)
+    options_path = Path(args.options)
+    output_dir = Path(args.output)
+    output_dir.mkdir(exist_ok=True)
+
+    underlying_df = engineer_underlying_features(underlying_path)
+    latest_date = underlying_df['Date'].max()
+    options_df = engineer_option_features(options_path, latest_date)
+
+    underlying_df.to_csv(output_dir / "underlying_features.csv", index=False)
+    options_df.to_csv(output_dir / "options_features.csv", index=False)
+    print(f"Saved engineered features to {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/model_selection.py
+++ b/model_selection.py
@@ -1,0 +1,78 @@
+import argparse
+from pathlib import Path
+import pandas as pd
+
+try:
+    from sklearn.linear_model import LogisticRegression
+    from sklearn.ensemble import RandomForestClassifier
+    from sklearn.model_selection import train_test_split
+except ImportError as exc:  # pragma: no cover - handle missing dependency
+    raise RuntimeError(
+        "scikit-learn is required. Try `pip install scikit-learn`."
+    ) from exc
+
+
+def load_dataset(features_path: Path) -> tuple[pd.DataFrame, pd.Series]:
+    """Prepare features and target for training.
+
+    The target is whether the next day's close is higher than today's.
+    """
+    df = pd.read_csv(features_path, parse_dates=["Date"])
+    df = df.sort_values("Date")
+    df["target"] = (df["Close"].shift(-1) > df["Close"]).astype(int)
+    df = df.dropna(subset=["target"])
+
+    feature_cols = [
+        c
+        for c in ["close_ma5", "close_ma20", "rsi14", "vol30d"]
+        if c in df.columns
+    ]
+    X = df[feature_cols].fillna(0)
+    y = df["target"]
+    return X, y
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train simple models on features")
+    parser.add_argument(
+        "underlying_features",
+        help="CSV from feature_engineering.py containing underlying features",
+    )
+    parser.add_argument(
+        "--output",
+        default="models",
+        help="Directory to store model accuracy results",
+    )
+    args = parser.parse_args()
+
+    X, y = load_dataset(Path(args.underlying_features))
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.3, random_state=42, shuffle=False
+    )
+
+    lr = LogisticRegression(max_iter=500)
+    rf = RandomForestClassifier(n_estimators=100, random_state=42)
+
+    # logistic regression requires at least two classes
+    lr_score = float("nan")
+    if y_train.nunique() > 1:
+        lr.fit(X_train, y_train)
+        lr_score = lr.score(X_test, y_test)
+
+    rf.fit(X_train, y_train)
+    rf_score = rf.score(X_test, y_test)
+
+    output_dir = Path(args.output)
+    output_dir.mkdir(exist_ok=True)
+    scores_path = output_dir / "scores.txt"
+    scores_path.write_text(
+        f"logistic_regression={lr_score:.4f}\nrandom_forest={rf_score:.4f}\n"
+    )
+
+    print(f"Logistic Regression accuracy: {lr_score:.4f}")
+    print(f"Random Forest accuracy: {rf_score:.4f}")
+    print(f"Saved scores to {scores_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/preprocess_data.py
+++ b/preprocess_data.py
@@ -1,0 +1,49 @@
+import argparse
+from pathlib import Path
+import pandas as pd
+
+
+def preprocess_underlying(csv_path: Path) -> pd.DataFrame:
+    """Clean and add basic features to underlying data."""
+    df = pd.read_csv(csv_path, parse_dates=['Date'])
+    df = df.sort_values('Date').drop_duplicates()
+    df = df.ffill()
+    df['close_ma5'] = df['Close'].rolling(5).mean()
+    df['close_ma20'] = df['Close'].rolling(20).mean()
+    df['returns'] = df['Close'].pct_change()
+    return df
+
+
+def preprocess_options(csv_path: Path, underlying_price: float) -> pd.DataFrame:
+    """Clean options data and compute simple features."""
+    df = pd.read_csv(csv_path)
+    df = df.drop_duplicates()
+    df['spread'] = df['Ask'] - df['Bid']
+    df['moneyness'] = (underlying_price - df['Strike']) / df['Strike']
+    df = df.fillna(0)
+    return df
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Preprocess underlying and options data")
+    parser.add_argument("underlying", help="CSV file with historical underlying data")
+    parser.add_argument("options", help="CSV file with options chain")
+    parser.add_argument("--output", default="cleaned", help="Directory to store processed CSV files")
+    args = parser.parse_args()
+
+    underlying_path = Path(args.underlying)
+    options_path = Path(args.options)
+    output_dir = Path(args.output)
+    output_dir.mkdir(exist_ok=True)
+
+    underlying_df = preprocess_underlying(underlying_path)
+    latest_close = underlying_df['Close'].iloc[-1]
+    options_df = preprocess_options(options_path, latest_close)
+
+    underlying_df.to_csv(output_dir / "underlying_clean.csv", index=False)
+    options_df.to_csv(output_dir / "options_clean.csv", index=False)
+    print(f"Saved cleaned data to {output_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement a Streamlit dashboard to display price charts, RSI/volatility, model scores and option features
- document how to launch the dashboard in the README

## Testing
- `python -m py_compile collect_data.py preprocess_data.py feature_engineering.py model_selection.py dashboard.py`
- `python preprocess_data.py sample_data/AAPL_underlying.csv sample_data/AAPL_options.csv --output processed`
- `python feature_engineering.py processed/underlying_clean.csv processed/options_clean.csv --output features`
- `python model_selection.py features/underlying_features.csv --output models`


------
https://chatgpt.com/codex/tasks/task_e_6850f79d25d88326b4d9c2d387c83d67