### PR TITLE
Add Webull paper trading instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,38 @@ The dashboard displays price charts with moving averages, RSI and volatility
 curves, the latest model accuracy scores, and a snapshot of recent option
 features.
 
+## Webull Paper Trading
+
+This project can integrate with the unofficial `webull` Python package to
+submit simulated trades. Install the package (also included in
+`requirements.txt`):
+
+```bash
+python3 -m pip install webull
+```
+
+Authenticate with the `paper_webull` class and send orders:
+
+```python
+from webull import paper_webull
+wb = paper_webull()
+wb.login('your_email', 'your_password')
+wb.get_trade_token('123456')  # your trade PIN
+wb.place_order(stock='AAPL', price=90.0, qty=2)
+```
+
+If Multi-Factor Authentication (MFA) is enabled, request codes with
+`wb.get_mfa()` and `wb.get_security()` before logging in. You may view or
+cancel orders with:
+
+```python
+orders = wb.get_current_orders()
+wb.cancel_all_orders()
+```
+
+These commands operate on Webull's paper trading environment. Review Webull's
+documentation and disclaimers before executing live trades.
+
 ## Disclaimer
 
 This project is for educational purposes only. Trading options involves significant risk, and no outcome is guaranteed. You are solely responsible for any trades executed using code or models derived from this repository.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ scikit-learn
 streamlit
 stable-baselines3
 gym
+webull


### PR DESCRIPTION
## Summary
- document how to use Webull for paper trading
- mention MFA steps and example usage
- add `webull` to requirements

## Testing
- `python -m py_compile collect_data.py feature_engineering.py preprocess_data.py dashboard.py model_selection.py reinforcement_model.py`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_6851dfb3ec6c8326b6be928b77b62b11