### PR TITLE
Add interactive scanner controls to dashboard

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -43,19 +43,29 @@ def main() -> None:
     st.subheader("Latest Option Features")
     st.dataframe(options_df.tail())
 
-    st.subheader("Gap and Go Scanner (sample)")
-    gappers = scan_gappers(["AAPL"], sample_dir=Path("sample_data"))
-    if not gappers.empty:
-        st.table(gappers)
-    else:
-        st.write("No gappers found.")
+    st.subheader("Scanner Settings")
+    tickers = st.text_input("Tickers (comma separated)", "AAPL")
+    gap_threshold = st.slider("Gap threshold", min_value=0.01, max_value=0.10, value=0.04, step=0.01)
+    use_sample = st.checkbox("Use sample CSV data", value=False)
+    run_scan = st.button("Run Scanners")
 
-    st.subheader("HOD Breakouts (sample)")
-    breakouts = scan_hod_breakouts(["AAPL"], sample_dir=Path("sample_data"))
-    if not breakouts.empty:
-        st.table(breakouts)
-    else:
-        st.write("No breakouts found.")
+    if run_scan:
+        ticker_list = [t.strip().upper() for t in tickers.split(",") if t.strip()]
+        sample_dir = Path("sample_data") if use_sample else None
+
+        st.subheader("Gap and Go Results")
+        gappers = scan_gappers(ticker_list, gap_threshold=gap_threshold, sample_dir=sample_dir)
+        if not gappers.empty:
+            st.table(gappers)
+        else:
+            st.write("No gappers found.")
+
+        st.subheader("HOD Breakout Results")
+        breakouts = scan_hod_breakouts(ticker_list, sample_dir=sample_dir)
+        if not breakouts.empty:
+            st.table(breakouts)
+        else:
+            st.write("No breakouts found.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow custom ticker list, gap threshold, and sample data option
- display scanner results interactively

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6877f43446d083269e74badfcd652a52